### PR TITLE
Docker compatibility. Changed config kafka_http_reporter.port

### DIFF
--- a/src/cloudkarafka/kafka_http_reporter.clj
+++ b/src/cloudkarafka/kafka_http_reporter.clj
@@ -88,7 +88,7 @@
 
 (defn -init [this metrics]
   (let [config (:kafka-config @state)
-        port (Integer/parseInt (or (:kafka_http_reporter.port config) "19092"))]
+        port (Integer/parseInt (or (:kafkahttpreporter.port config) "19092"))]
     (println "[INFO] KafkaHttpReporter: Starting HTTP server on port " port )
     (swap! state assoc :http-server (http/start-server handler {:port port}))))
 


### PR DESCRIPTION
Docker compatibility. Changed config kafka_http_reporter.port to kafkahttpreporter.port. This allows the use of environment variables when using Docker. The use of the underscores prevented the use of environment variables.

For example, in docker-compose, we can set the port with KAFKA_KAFKAHTTPREPORTER_PORT: 19094